### PR TITLE
Add check for autoload file and bail early if plugin class is missing.

### DIFF
--- a/rocket-launch-slack-notifier.php
+++ b/rocket-launch-slack-notifier.php
@@ -7,7 +7,15 @@ Version:     1.0
 Author URI:  https://www.binarygary.com/
 */
 
-require_once trailingslashit( __DIR__ ) . 'vendor/autoload.php';
+$autoload = trailingslashit( __DIR__ ) . 'vendor/autoload.php';
+
+if ( file_exists( $autoload ) ) {
+	require_once $autoload;
+}
+
+if ( ! class_exists( '\BinaryGary\Rocket\Core', false ) ) {
+	return;
+}
 
 // Start the core plugin
 add_action( 'plugins_loaded', function () {


### PR DESCRIPTION
This PR will check for the presence of the autoload.php file and attempt to load it from the plugin directory if it exists. After, it will check for the existence of the plugin class, bailing early if it's not found, because that means no autoloader was loaded from anywhere within the WordPress installation.